### PR TITLE
Feature/word card Issue #95の解消

### DIFF
--- a/src/lib/components/WordCard.svelte
+++ b/src/lib/components/WordCard.svelte
@@ -101,9 +101,11 @@
   font-size: 0.85rem;
   line-height: 1.45;
   color: #111827;
+  text-indent: 1rem;
+  
 
   /*ポップアップの見た目*/
-  padding: 0.8rem 1rem;
+  padding: 0.5rem 1.0rem;
   background: #ffffff;
   border-radius: 10px;
   border: 1px solid #e5e7eb;
@@ -130,29 +132,30 @@
 
 .popup strong {
   display: block;
-  font-size: 0.9rem;
+  font-size: 1.2rem;
   color: #0f172a;
+  text-indent: 0;
 }
 
 .desc {
-  margin-top: 0.35rem;
   color: #374151;
   display: block;
+  text-indent: 1;
 }
 
 .tags {
-  margin-top: 0.55rem;
+  margin-top: 0.3rem;
   display: block;
+  text-indent: 0;
 }
+
 
 .tag {
   display: inline-block;
   margin: 0.1rem 0.25rem 0 0;
   padding: 0.15rem 0.45rem;
-
   font-size: 0.68rem;
-  border-radius: 999px;
-
+  border-radius: 9rem;
   background: #eef2ff;
   color: #1e3a8a;
   border: 1px solid #c7d2fe;

--- a/src/lib/components/WordCard.svelte
+++ b/src/lib/components/WordCard.svelte
@@ -95,7 +95,7 @@
   /*表示位置設定*/
   position: absolute;
   bottom: 140%;
-  left: 0;
+  
 
   /*テキストスタイル*/
   font-size: 0.85rem;


### PR DESCRIPTION
WordCardポップアップ内のタグ表示に関する不具合修正
・タグ名が右寄りになる現象の改善
・タグカードが2列にわたる場合,改行位置がずれる現象の改善

Closes #95 