### PR TITLE
モバイル版WordCardを描画しないように設定

### DIFF
--- a/src/lib/components/WordCard.svelte
+++ b/src/lib/components/WordCard.svelte
@@ -165,4 +165,16 @@
   color: #dc2626;
   border-bottom: 1px dashed #dc2626;
 }
+
+@media (max-width: 768px) {
+  .popup {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .popup {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
モバイル版での挙動を制御しようと試みたけれど,今の技術力ではにっちもさっちも行かなかったので一旦非表示に.

Related #94 
